### PR TITLE
Add validation smoke test and Cursor Cloud dev setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent instructions — this repository
+
+This repo is **huanshankeji/.github**: organization profile, shared docs, composite GitHub Actions, and workflow templates. It is **not** a Gradle/Kotlin application. There is no `./gradlew`, dev server, or database to run here.
+
+For organization-wide Kotlin library standards and the public repo catalog, see [docs/general-agent-instructions.md](docs/general-agent-instructions.md).
+
+## Local validation (lint / test equivalent)
+
+Contributors validate YAML and metadata before pushing:
+
+```bash
+./scripts/validate.sh
+```
+
+| Check | Tool |
+| --- | --- |
+| Workflow templates | [actionlint](https://github.com/rhysd/actionlint) on `workflow-templates/*.yml` |
+| Composite actions | Python + PyYAML (actionlint expects workflow shape; do not pass `actions/*/action.yml` directly) |
+| YAML style | [yamllint](https://github.com/adrienverge/yamllint) (`relaxed` config inline in script) |
+| Template metadata | `json.load` on `workflow-templates/*.properties.json` |
+| Doc links | Relative links in `docs/` and `profile/README.md` |
+
+There is no `./gradlew build` or `./gradlew check` in this tree. Consumer Kotlin repos use the templates under `workflow-templates/` and actions under `actions/`.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `actions/` | Composite actions (`setup-javas`, `gradle-test-and-check`, `gradle-dependency-submission`) |
+| `workflow-templates/` | Starter CI / Dokka workflows for sibling libraries |
+| `docs/` | Kotlin style, dev snapshots, code review, agent baseline |
+| `profile/` | GitHub org profile README |
+
+## Cursor Cloud specific instructions
+
+- **No runtime services** are required for this repo (no Postgres, no Gradle daemon for local work).
+- **Validation tools:** `actionlint` is installed at `/usr/local/bin/actionlint` (v1.7.7). `yamllint` is installed via `pip3 install --user` (ensure `~/.local/bin` is on `PATH`).
+- **“Run the app”** means run `./scripts/validate.sh` — that is the project’s smoke test.
+- **Sibling Kotlin libraries** (gradle-common, kotlin-common, etc.) are separate clones; use JDK + `./gradlew check` per their README. Snapshot chaining is documented in [docs/dev-instructions.md](docs/dev-instructions.md).
+- **actionlint caveat:** Run it only on `workflow-templates/*.yml`. Composite `actions/*/action.yml` files are validated by the script’s PyYAML structural check instead.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Smoke test for huanshankeji/.github — validates Actions metadata and workflow templates.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+export PATH="${HOME}/.local/bin:${PATH}"
+
+echo "==> YAML (yamllint, relaxed)"
+yamllint -d relaxed actions/ workflow-templates/
+
+echo "==> Workflow templates (actionlint)"
+actionlint workflow-templates/*.yml
+
+echo "==> Composite actions (structure)"
+python3 << 'PY'
+import pathlib, sys, yaml
+
+required = {"name", "runs"}
+for path in sorted(pathlib.Path("actions").glob("*/action.yml")):
+    data = yaml.safe_load(path.read_text())
+    missing = required - set(data)
+    if missing:
+        print(f"FAIL {path}: missing {missing}", file=sys.stderr)
+        sys.exit(1)
+    if data.get("runs", {}).get("using") != "composite":
+        print(f"FAIL {path}: expected composite action", file=sys.stderr)
+        sys.exit(1)
+    print(f"OK {path}")
+PY
+
+echo "==> Workflow template metadata (JSON)"
+python3 << 'PY'
+import json, glob
+for p in sorted(glob.glob("workflow-templates/*.properties.json")):
+    with open(p) as f:
+        json.load(f)
+    print(f"OK {p}")
+PY
+
+echo "==> Markdown relative links"
+python3 << 'PY'
+import pathlib, re, sys
+
+root = pathlib.Path(".")
+md_files = list((root / "docs").glob("*.md")) + [root / "profile/README.md"]
+link_re = re.compile(r"\]\(([^)]+)\)")
+broken = []
+for md in md_files:
+    text = md.read_text()
+    for m in link_re.finditer(text):
+        target = m.group(1).split("#")[0].strip()
+        if not target or target.startswith("http"):
+            continue
+        if not (md.parent / target).resolve().exists():
+            broken.append((md, target))
+if broken:
+    for md, target in broken:
+        print(f"BROKEN {md}: {target}", file=sys.stderr)
+    sys.exit(1)
+print(f"OK {len(md_files)} markdown files")
+PY
+
+echo ""
+echo "All checks passed."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This repository is the Huanshankeji organization `.github` meta-repo (shared Actions, workflow templates, and docs)—not a runnable Kotlin/Gradle application. Cloud agent setup adds a repeatable local smoke test and documents how to work in this repo vs sibling libraries.

## Changes

- **`scripts/validate.sh`** — Runs yamllint, actionlint on workflow templates, PyYAML checks on composite actions, JSON metadata validation, and relative markdown link checks.
- **`AGENTS.md`** — Repo-specific agent guide plus **Cursor Cloud specific instructions** (no services to start; use `./scripts/validate.sh` as the smoke test).

## VM update script (proposed)

```
pip3 install --user -q yamllint
```

`actionlint` v1.7.7 is installed on the VM image at `/usr/local/bin/actionlint`.

## Verification

```bash
./scripts/validate.sh
# All checks passed.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1b8bbca-2327-497b-9ba3-63a15c5138fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1b8bbca-2327-497b-9ba3-63a15c5138fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

