### PR TITLE
Document main and release branch versioning conventions

### DIFF
--- a/docs/dev-instructions.md
+++ b/docs/dev-instructions.md
@@ -1,5 +1,10 @@
 # Development instructions
 
+## Branch versioning conventions
+
+- **`main`**: Must not use snapshot dependencies — only stable dependency versions. The project version is conventionally a snapshot version (for example `1.0.0-SNAPSHOT`).
+- **`release`**: Merges from `main` and carries a stable project version. Everything must be stable: dependency versions and the project version. No snapshot dependencies and no snapshot project version.
+
 ## Publish snapshot dependencies of our library projects to Maven local
 
 When you encounter a dependency of a snapshot version under our group prefix `com.huanshankeji` in a consuming project, follow these steps:

--- a/docs/dev-instructions.md
+++ b/docs/dev-instructions.md
@@ -2,8 +2,11 @@
 
 ## Branch versioning conventions
 
+- **`dev`**: Active development branch. Snapshot dependencies and a snapshot project version are both permitted.
 - **`main`**: Must not use snapshot dependencies — only stable dependency versions. The project version is conventionally a snapshot version (for example `1.0.0-SNAPSHOT`).
 - **`release`**: Merges from `main` and carries a stable project version. Everything must be stable: dependency versions and the project version. No snapshot dependencies and no snapshot project version.
+
+Other development or feature branches follow the same conventions as `dev` unless a maintainer specifies otherwise.
 
 ## Publish snapshot dependencies of our library projects to Maven local
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **Branch versioning conventions** section to `docs/dev-instructions.md`:

- **`dev`**: snapshot dependencies and snapshot project version permitted.
- **`main`**: stable dependency versions only; project version is conventionally a snapshot (e.g. `1.0.0-SNAPSHOT`).
- **`release`**: merges from `main` with a stable project version; all dependency and project versions must be stable.
- Other development/feature branches follow `dev` unless specified otherwise.

This complements the existing guidance on publishing snapshot dependencies to Maven local when working on consuming projects.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35c9330f-e137-4009-a361-510d38fb8959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35c9330f-e137-4009-a361-510d38fb8959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

