### PR TITLE
docs: add Kotlin trailing newline convention to code style guide

### DIFF
--- a/docs/kotlin-code-style.md
+++ b/docs/kotlin-code-style.md
@@ -3,3 +3,4 @@
 1. Try to golf the code, prefer `also`, `apply`, `let`, `run` to `if`-`else` when they shorten the code, and try all of them and use the shortest one.
 1. In most cases, don't create a variable if it is used only once, unless extracting variables greatly improves readability. However, when you see existing code using or not using variables used only once, don't try to change it unless you are a maintainer and decide on a better way.
 1. For a long comment paragraph that spans multiple lines, use block comments instead of multiple lines of single-line comments.
+1. Trailing newline: follow Kotlin's default IntelliJ IDEA convention — omit a trailing newline for a single-class file, include one for files with multiple top-level definitions, and do not add or remove an existing trailing newline when editing a file (to avoid unnecessary git diff churn).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a trailing-newline convention to `docs/kotlin-code-style.md`, aligned with Kotlin's default IntelliJ IDEA behavior:

- **Single-class files:** no trailing newline
- **Files with multiple top-level definitions:** include a trailing newline
- **When editing existing files:** preserve the existing trailing-newline state to avoid unnecessary git diff churn
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae19f5b4-c9af-432c-82bc-b7cc5f0cea75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae19f5b4-c9af-432c-82bc-b7cc5f0cea75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

