### PR TITLE
docs: reference kotlin-skills and skills in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,29 +2,9 @@
 
 This repo is **huanshankeji/.github**: organization profile, shared docs, composite GitHub Actions, and workflow templates. It is **not** a Gradle/Kotlin application. There is no `./gradlew`, dev server, or database to run here.
 
-For organization-wide Kotlin library standards, the public repo catalog, and shared workflows, see [docs/general-agent-instructions.md](docs/general-agent-instructions.md).
+For organization-wide Kotlin library standards, the public repo catalog, shared workflows, and [agent skills](docs/general-agent-instructions.md#agent-skills), see [docs/general-agent-instructions.md](docs/general-agent-instructions.md).
 
 The `copilot/` directory is **no longer maintained**. Do not edit files there; use this `AGENTS.md` and `docs/` instead.
-
-## Agent skills
-
-When a task matches a published [Agent Skills](https://agentskills.io) workflow, load and follow that skill instead of improvising steps. Full catalog and installation options are in [docs/general-agent-instructions.md#agent-skills](docs/general-agent-instructions.md#agent-skills).
-
-| Repository | Use for |
-| --- | --- |
-| [kotlin-skills](https://github.com/huanshankeji/kotlin-skills) | Kotlin, Gradle, and JVM/KMP workflows (for example `gradle-wrapper-update`, `kotlin-debugging-unresolved-reference-file-clash`) |
-| [skills](https://github.com/huanshankeji/skills) | General-purpose skills across stacks |
-
-Install with the [skills CLI](https://github.com/vercel-labs/skills):
-
-```bash
-npx skills add huanshankeji/kotlin-skills
-npx skills add huanshankeji/skills
-```
-
-Or copy individual skill folders from a repo’s `skills/` directory into a project-local path (for example `.github/skills/`, `.claude/skills/`, or `.agents/skills/`).
-
-Also see [Kotlin/kotlin-agent-skills](https://github.com/Kotlin/kotlin-agent-skills) for skills maintained by JetBrains.
 
 ## Layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent instructions — this repository
+
+This repo is **huanshankeji/.github**: organization profile, shared docs, composite GitHub Actions, and workflow templates. It is **not** a Gradle/Kotlin application. There is no `./gradlew`, dev server, or database to run here.
+
+For organization-wide Kotlin library standards, the public repo catalog, and shared workflows, see [docs/general-agent-instructions.md](docs/general-agent-instructions.md).
+
+The `copilot/` directory is **no longer maintained**. Do not edit files there; use this `AGENTS.md` and `docs/` instead.
+
+## Agent skills
+
+When a task matches a published [Agent Skills](https://agentskills.io) workflow, load and follow that skill instead of improvising steps. Full catalog and installation options are in [docs/general-agent-instructions.md#agent-skills](docs/general-agent-instructions.md#agent-skills).
+
+| Repository | Use for |
+| --- | --- |
+| [kotlin-skills](https://github.com/huanshankeji/kotlin-skills) | Kotlin, Gradle, and JVM/KMP workflows (for example `gradle-wrapper-update`, `kotlin-debugging-unresolved-reference-file-clash`) |
+| [skills](https://github.com/huanshankeji/skills) | General-purpose skills across stacks |
+
+Install with the [skills CLI](https://github.com/vercel-labs/skills):
+
+```bash
+npx skills add huanshankeji/kotlin-skills
+npx skills add huanshankeji/skills
+```
+
+Or copy individual skill folders from a repo’s `skills/` directory into a project-local path (for example `.github/skills/`, `.claude/skills/`, or `.agents/skills/`).
+
+Also see [Kotlin/kotlin-agent-skills](https://github.com/Kotlin/kotlin-agent-skills) for skills maintained by JetBrains.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `actions/` | Composite actions (`setup-javas`, `gradle-test-and-check`, `gradle-dependency-submission`) |
+| `workflow-templates/` | Starter CI / Dokka workflows for sibling libraries |
+| `docs/` | Kotlin style, dev snapshots, code review, agent baseline |
+| `profile/` | GitHub org profile README |
+
+Consumer Kotlin libraries (gradle-common, kotlin-common, etc.) are separate clones. Use JDK and `./gradlew check` per their README. Snapshot chaining is documented in [docs/dev-instructions.md](docs/dev-instructions.md).

--- a/copilot/copilot-spaces.md
+++ b/copilot/copilot-spaces.md
@@ -8,10 +8,6 @@ Short description: Develop and iterate on the libraries of @huanshankeji as a wh
 
 ### Instructions
 
-You are a developer. Follow the docs in the source repositories — especially [general-agent-instructions.md](../docs/general-agent-instructions.md) — to develop and iterate on the snapshot versions of our projects.
-
-When a task matches an [agent skill](https://github.com/huanshankeji/.github/blob/main/docs/general-agent-instructions.md#agent-skills), use it: install from [kotlin-skills](https://github.com/huanshankeji/kotlin-skills) or [skills](https://github.com/huanshankeji/skills) and follow the skill’s `SKILL.md` (for example `gradle-wrapper-update` for Gradle wrapper changes, or `kotlin-debugging-unresolved-reference-file-clash` for misleading Kotlin “Unresolved reference” errors).
-
-When you encounter a dependency of a snapshot version under the group prefix `com.huanshankeji` in a consuming project, you should run `publishToMavenLocal` in the dependency project first to make the consuming project build. Prefer `dev` branches over `main` and other branches in the dependency branch. And if one branch causes the consuming project not to build, you should try switching to other branches in the dependency project, preferably those with newer commits.
+You are a developer. Follow the docs in the source repositories to develop and iterate on the snapshot versions of our projects. When you encounter a dependency of a snapshot version under the group prefix `com.huanshankeji` in a consuming project, you should run `publishToMavenLocal` in the dependency project first to make the consuming project build. Prefer `dev` branches over `main` and other branches in the dependency branch. An if one branch causes the consuming project not to build, you should try switching to other branches in the dependency project, preferably those with newer commits.
 
 Do this recursively, which is to say, if you encounter a snapshot dependency in the dependency project, treat the dependency project as another consuming project and configure its dependency projects in this way too.

--- a/copilot/copilot-spaces.md
+++ b/copilot/copilot-spaces.md
@@ -8,6 +8,10 @@ Short description: Develop and iterate on the libraries of @huanshankeji as a wh
 
 ### Instructions
 
-You are a developer. Follow the docs in the source repositories to develop and iterate on the snapshot versions of our projects. When you encounter a dependency of a snapshot version under the group prefix `com.huanshankeji` in a consuming project, you should run `publishToMavenLocal` in the dependency project first to make the consuming project build. Prefer `dev` branches over `main` and other branches in the dependency branch. An if one branch causes the consuming project not to build, you should try switching to other branches in the dependency project, preferably those with newer commits.
+You are a developer. Follow the docs in the source repositories — especially [general-agent-instructions.md](../docs/general-agent-instructions.md) — to develop and iterate on the snapshot versions of our projects.
+
+When a task matches an [agent skill](https://github.com/huanshankeji/.github/blob/main/docs/general-agent-instructions.md#agent-skills), use it: install from [kotlin-skills](https://github.com/huanshankeji/kotlin-skills) or [skills](https://github.com/huanshankeji/skills) and follow the skill’s `SKILL.md` (for example `gradle-wrapper-update` for Gradle wrapper changes, or `kotlin-debugging-unresolved-reference-file-clash` for misleading Kotlin “Unresolved reference” errors).
+
+When you encounter a dependency of a snapshot version under the group prefix `com.huanshankeji` in a consuming project, you should run `publishToMavenLocal` in the dependency project first to make the consuming project build. Prefer `dev` branches over `main` and other branches in the dependency branch. And if one branch causes the consuming project not to build, you should try switching to other branches in the dependency project, preferably those with newer commits.
 
 Do this recursively, which is to say, if you encounter a snapshot dependency in the dependency project, treat the dependency project as another consuming project and configure its dependency projects in this way too.

--- a/docs/general-agent-instructions.md
+++ b/docs/general-agent-instructions.md
@@ -37,12 +37,11 @@ Also see [Kotlin/kotlin-agent-skills](https://github.com/Kotlin/kotlin-agent-ski
 
 ### Installation
 
-Install into the target repository (or your global skills directory) with the [skills CLI](https://github.com/vercel-labs/skills). Skills live in subdirectories under each repo’s `skills/` folder, so point at a specific skill path:
+Install into the target repository (or your global skills directory) with the [skills CLI](https://github.com/vercel-labs/skills):
 
 ```bash
-npx skills add huanshankeji/kotlin-skills/skills/gradle-wrapper-update
-npx skills add huanshankeji/kotlin-skills/skills/kotlin-debugging-unresolved-reference-file-clash
-npx skills add huanshankeji/skills/skills/<skill-name>
+npx skills add huanshankeji/kotlin-skills
+npx skills add huanshankeji/skills
 ```
 
 Or copy individual skill folders from a repo’s `skills/` directory into a project-local skills path (for example `.agents/skills/`, `.github/skills/`, or `.claude/skills/`). See each repository’s README for layout details.

--- a/docs/general-agent-instructions.md
+++ b/docs/general-agent-instructions.md
@@ -24,6 +24,41 @@ This file is [`docs/general-agent-instructions.md`](https://github.com/huanshank
 
 ---
 
+## Agent skills
+
+We publish reusable [Agent Skills](https://agentskills.io) for workflows that agents should not improvise. **When a task matches a skill’s description, load and follow that skill** (via your platform’s skill tool, or by reading the skill’s `SKILL.md`) instead of inventing steps from scratch.
+
+| Repository | Scope |
+| --- | --- |
+| [kotlin-skills](https://github.com/huanshankeji/kotlin-skills) | Kotlin, Gradle, and JVM/KMP build workflows |
+| [skills](https://github.com/huanshankeji/skills) | General agent skills (not Kotlin-specific) |
+
+Also see [Kotlin/kotlin-agent-skills](https://github.com/Kotlin/kotlin-agent-skills) for skills maintained by JetBrains.
+
+### Installation
+
+Install into the target repository (or your global skills directory) with the [skills CLI](https://github.com/vercel-labs/skills):
+
+```bash
+npx skills add huanshankeji/kotlin-skills
+npx skills add huanshankeji/skills
+```
+
+Or copy individual skill folders from a repo’s `skills/` directory into a project-local skills path (for example `.github/skills/`, `.claude/skills/`, or `.agents/skills/`). See each repository’s README for layout details.
+
+### kotlin-skills catalog
+
+| Skill | Use when |
+| --- | --- |
+| [gradle-wrapper-update](https://github.com/huanshankeji/kotlin-skills/tree/main/skills/gradle-wrapper-update) | Upgrading or downgrading the Gradle wrapper (`gradlew`, `gradle-wrapper.properties`, `gradle-wrapper.jar`) |
+| [kotlin-debugging-unresolved-reference-file-clash](https://github.com/huanshankeji/kotlin-skills/tree/main/skills/kotlin-debugging-unresolved-reference-file-clash) | Kotlin JVM or KMP reports “Unresolved reference” (or similar) even though the symbol exists and dependencies look correct — especially after adding, moving, or renaming `.kt` files with top-level declarations |
+
+### skills catalog
+
+Check [skills](https://github.com/huanshankeji/skills) for general-purpose skills that apply across stacks. Prefer a repo-local or org skill over ad hoc steps when one matches the task.
+
+---
+
 ## Open source Kotlin project hierarchy
 
 **Only public, non-fork Kotlin repositories** created by `@huanshankeji` are listed below.
@@ -77,6 +112,7 @@ flowchart TB
 ### Related organization resources
 
 - **Profile / intro:** [profile/README.md](../profile/README.md)
+- **Agent skills:** [kotlin-skills](https://github.com/huanshankeji/kotlin-skills), [skills](https://github.com/huanshankeji/skills) — see [Agent skills](#agent-skills)
 - **Shared CI & Actions:** workflow templates and composite actions in this repo (`workflow-templates/`, `actions/`)
 
 ---
@@ -85,6 +121,7 @@ flowchart TB
 
 1. Open the target repo and read its `README.md`, `CONTRIBUTING.md`, and any repo-local agent file (`AGENTS.md`, `.github/copilot-instructions.md`).
 2. Apply the [required reading](#required-reading) for the task type.
-3. If the task spans multiple repos (typical on `dev` with snapshots), follow [dev-instructions.md](dev-instructions.md) before running `./gradlew check` or `./gradlew build`.
+3. If the task matches an [agent skill](#agent-skills) (Gradle wrapper updates, misleading Kotlin “Unresolved reference” errors, or a skill in [skills](https://github.com/huanshankeji/skills)), install or load that skill and follow it.
+4. If the task spans multiple repos (typical on `dev` with snapshots), follow [dev-instructions.md](dev-instructions.md) before running `./gradlew check` or `./gradlew build`.
 
 When instructions conflict, **repo-local agent docs and maintainers’ task directions win**; this file provides the shared baseline and library map.

--- a/docs/general-agent-instructions.md
+++ b/docs/general-agent-instructions.md
@@ -37,14 +37,17 @@ Also see [Kotlin/kotlin-agent-skills](https://github.com/Kotlin/kotlin-agent-ski
 
 ### Installation
 
-Install into the target repository (or your global skills directory) with the [skills CLI](https://github.com/vercel-labs/skills):
+Install into the target repository (or your global skills directory) with the [skills CLI](https://github.com/vercel-labs/skills). Skills live in subdirectories under each repo’s `skills/` folder, so point at a specific skill path:
 
 ```bash
-npx skills add huanshankeji/kotlin-skills
-npx skills add huanshankeji/skills
+npx skills add huanshankeji/kotlin-skills/skills/gradle-wrapper-update
+npx skills add huanshankeji/kotlin-skills/skills/kotlin-debugging-unresolved-reference-file-clash
+npx skills add huanshankeji/skills/skills/<skill-name>
 ```
 
-Or copy individual skill folders from a repo’s `skills/` directory into a project-local skills path (for example `.github/skills/`, `.claude/skills/`, or `.agents/skills/`). See each repository’s README for layout details.
+Or copy individual skill folders from a repo’s `skills/` directory into a project-local skills path (for example `.agents/skills/`, `.github/skills/`, or `.claude/skills/`). See each repository’s README for layout details.
+
+Do **not** commit installed skill files to the repository unless explicitly asked to install skills there.
 
 ### kotlin-skills catalog
 

--- a/docs/general-agent-instructions.md
+++ b/docs/general-agent-instructions.md
@@ -2,7 +2,7 @@
 
 Instructions for AI coding agents working on **public Kotlin libraries** published by [Chengdu Huanshan Technology](https://github.com/huanshankeji) (`@huanshankeji`). We focus on [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html), [Vert.x](https://vertx.io/), functional programming, and type-safety.
 
-This file is [`docs/general-agent-instructions.md`](https://github.com/huanshankeji/.github/blob/main/docs/general-agent-instructions.md) in the [`.github`](https://github.com/huanshankeji/.github) organization repository. Individual projects may add their own `AGENTS.md`, `CLAUDE.md`, or `.github/copilot-instructions.md`; **follow those for repo-specific build steps and architecture**, and use this file for organization-wide standards and library relationships.
+This file is [`docs/general-agent-instructions.md`](https://github.com/huanshankeji/.github/blob/main/docs/general-agent-instructions.md) in the [`.github`](https://github.com/huanshankeji/.github) organization repository. For **this** repo, start with the root [`AGENTS.md`](../AGENTS.md). Other projects may add their own `AGENTS.md`, `CLAUDE.md`, or `.github/copilot-instructions.md`; **follow those for repo-specific build steps and architecture**, and use this file for organization-wide standards and library relationships.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates organization-wide AI agent documentation to point agents at our published [Agent Skills](https://agentskills.io) repositories when relevant workflows are covered there.

## Changes

- **`AGENTS.md`** (new)
  - Repo-specific entry point for agents working in **huanshankeji/.github**
  - Links to [agent skills](docs/general-agent-instructions.md#agent-skills) in `docs/general-agent-instructions.md` (no duplicated catalog)
  - Notes that `copilot/` is no longer maintained

- **`docs/general-agent-instructions.md`**
  - New **Agent skills** section covering kotlin-skills, skills, installation, and catalog entries
  - Per-skill `npx skills add` paths under each repo’s `skills/` subdirectory
  - Prefer `.agents/skills/` for manual installs; do not commit installed skills unless explicitly requested
  - Points agents at root `AGENTS.md` for this repo
  - Added skills to **Related organization resources**
  - Added a workflow step under **Working on a single repository** to load matching skills before improvising

- **`copilot/copilot-spaces.md`**
  - Restored to `main` (directory is unmaintained; no further edits there)

## Motivation

Agents working on Huanshankeji Kotlin repos should follow tested skill workflows (e.g. running the Gradle wrapper task twice, diagnosing file-facade clashes) instead of reinventing steps that are already documented in our skill repos. Agent guidance for this org repo now lives in `AGENTS.md` rather than the legacy `copilot/` directory.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d57a28b7-5678-45c7-94a5-b730d650a068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d57a28b7-5678-45c7-94a5-b730d650a068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

