### PR TITLE
Enable Gradle build-cache writes on feature-branch CI

### DIFF
--- a/.github/workflows/gradle-ci.yml
+++ b/.github/workflows/gradle-ci.yml
@@ -20,11 +20,27 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # setup-javas-and-gradle defaults cache-read-only: false so non-main branches
+      # persist Gradle User Home / local build cache (Actions caches are branch-scoped).
       - name: Set up JDKs and Gradle
-        uses: huanshankeji/.github/actions/setup-javas-and-gradle@v0.4.1
+        uses: huanshankeji/.github/actions/setup-javas-and-gradle@cursor/gradle-cache-write-feature-branches
         with:
           jdk-versions: ${{ inputs.jdk-versions }}
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      # setup-gradle@v6 no longer persists configuration-cache entries the way older
+      # setups did. Entries live under .gradle/configuration-cache in the checkout;
+      # restoring buildSrc/build avoids false invalidation when buildSrc task inputs
+      # appear to have changed.
+      - name: Cache Gradle configuration cache and buildSrc
+        uses: actions/cache@v4
+        with:
+          path: |
+            .gradle/configuration-cache
+            buildSrc/build
+          key: ${{ runner.os }}-${{ runner.arch }}-configcache-check-${{ hashFiles('**/*.gradle.kts', '**/*.gradle', 'gradle.properties', 'gradle/wrapper/gradle-wrapper.properties', 'buildSrc/**/*.kt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-configcache-check-
 
       - name: Check with Gradle Wrapper
         env:

--- a/.github/workflows/open-source-convention-gradle-maven-publish.yml
+++ b/.github/workflows/open-source-convention-gradle-maven-publish.yml
@@ -23,11 +23,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # setup-javas-and-gradle defaults cache-read-only: false so non-main branches
+      # persist Gradle User Home / local build cache (Actions caches are branch-scoped).
       - name: Set up JDKs and Gradle
-        uses: huanshankeji/.github/actions/setup-javas-and-gradle@v0.4.1
+        uses: huanshankeji/.github/actions/setup-javas-and-gradle@cursor/gradle-cache-write-feature-branches
         with:
           jdk-versions: ${{ inputs.jdk-versions }}
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      # Cache buildSrc outputs only. Publish often disables configuration cache, and
+      # commit-based snapshot versions churn CC inputs — do not Action-cache
+      # .gradle/configuration-cache here.
+      - name: Cache buildSrc outputs
+        uses: actions/cache@v4
+        with:
+          path: buildSrc/build
+          key: ${{ runner.os }}-${{ runner.arch }}-buildsrc-${{ hashFiles('buildSrc/**/*.kt', 'buildSrc/**/*.kts', 'buildSrc/**/*.gradle*', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-buildsrc-
 
       - name: Publish with Gradle Wrapper
         env:

--- a/actions/setup-javas-and-gradle/action.yml
+++ b/actions/setup-javas-and-gradle/action.yml
@@ -2,7 +2,10 @@ name: Setup JDKs and Gradle
 description: >
   Sets up the requested JDKs via setup-javas, then configures Gradle with
   setup-gradle (Enhanced Caching by default) and a configuration-cache
-  encryption key for cross-job cache reuse.
+  encryption key for cross-job cache reuse. Cache writes are enabled on all
+  branches by default (cache-read-only: false) so feature-branch CI can persist
+  Gradle User Home / local build-cache entries; GitHub Actions caches are
+  branch-scoped anyway.
 
 inputs:
   jdk-versions:
@@ -12,6 +15,13 @@ inputs:
   cache-encryption-key:
     description: "Base64 AES key for encrypting configuration-cache entries in the Actions cache (pass secrets.GRADLE_ENCRYPTION_KEY; empty skips config-cache caching)"
     required: true
+  # setup-gradle defaults cache-read-only to true on non-default branches, which
+  # restores caches but never saves them — successive feature-branch runs cannot
+  # reuse local build-cache outputs. Override to false so all branches write.
+  cache-read-only:
+    description: "When true, restore Gradle caches but do not save (setup-gradle default on non-default branches). Default false so feature branches persist build cache."
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -25,3 +35,4 @@ runs:
       uses: gradle/actions/setup-gradle@v6
       with:
         cache-encryption-key: ${{ inputs.cache-encryption-key }}
+        cache-read-only: ${{ inputs.cache-read-only }}

--- a/docs/dev-instructions.md
+++ b/docs/dev-instructions.md
@@ -84,7 +84,7 @@ dependencyResolutionManagement {
   - GitHub Packages (org secrets): `GPR_USER`, `GPR_KEY`
   - Maven Central + signing (org secrets, release publish): `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`, `SIGNING_IN_MEMORY_KEY_PASSWORD`
   - Configuration-cache encryption for the Actions cache (org secret): `GRADLE_ENCRYPTION_KEY` (passed into `setup-gradle` / `dependency-submission` as `cache-encryption-key`). If this secret is missing, the workflow still runs but configuration-cache entries are not stored in the Actions cache (`setup-gradle` warns).
-- Caching: `gradle/actions` v6 Enhanced Caching is the default (no workflow override). Enable Gradle caches in the consumer’s `gradle.properties` — not via CLI flags in CI:
+- Caching: `gradle/actions` v6 Enhanced Caching is the default. `setup-javas-and-gradle` sets `cache-read-only: false` so feature branches write Gradle User Home / local build-cache entries (setup-gradle’s default is read-only on non-default branches; Actions caches are branch-scoped anyway). Reusable `gradle-ci.yml` also caches `.gradle/configuration-cache` and `buildSrc/build`; publish caches `buildSrc/build` only. Enable Gradle caches in the consumer’s `gradle.properties` — not via CLI flags in CI:
   - `org.gradle.caching=true`
   - `org.gradle.configuration-cache=true`
 - Publish on all branches (`push: branches: ["**"]`). On `release`: `./gradlew publishAndReleaseToMavenCentral`; otherwise `./gradlew publishAllPublicationsToGitHubPackagesRepository --parallel`.

--- a/workflow-templates/dokka-gh-pages.yml
+++ b/workflow-templates/dokka-gh-pages.yml
@@ -45,6 +45,9 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          # Write Gradle User Home / build-cache on every branch (default is read-only off main).
+          cache-read-only: false
 
       - name: Build the distribution with Gradle Wrapper
         run: ./gradlew :dokkaGeneratePublicationHtml

--- a/workflow-templates/kotlin-jvm-ci.yml
+++ b/workflow-templates/kotlin-jvm-ci.yml
@@ -23,6 +23,9 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          # Write Gradle User Home / build-cache on every branch (default is read-only off main).
+          cache-read-only: false
 
       - name: Check with Gradle Wrapper
         run: ./gradlew check

--- a/workflow-templates/kotlin-multiplatform-ci.yml
+++ b/workflow-templates/kotlin-multiplatform-ci.yml
@@ -23,6 +23,9 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          # Write Gradle User Home / build-cache on every branch (default is read-only off main).
+          cache-read-only: false
 
       - name: Check with Gradle Wrapper
         run: ./gradlew check

--- a/workflow-templates/team-ci.yml
+++ b/workflow-templates/team-ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    uses: huanshankeji/.github/.github/workflows/gradle-ci.yml@v0.4.1
+    uses: huanshankeji/.github/.github/workflows/gradle-ci.yml@cursor/gradle-cache-write-feature-branches
     secrets: inherit
     with:
       jdk-versions: 11-temurin, 17-temurin

--- a/workflow-templates/team-publish.yml
+++ b/workflow-templates/team-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    uses: huanshankeji/.github/.github/workflows/open-source-convention-gradle-maven-publish.yml@v0.4.1
+    uses: huanshankeji/.github/.github/workflows/open-source-convention-gradle-maven-publish.yml@cursor/gradle-cache-write-feature-branches
     secrets: inherit
     with:
       jdk-versions: 11-temurin, 17-temurin


### PR DESCRIPTION
## Summary
- Default `setup-javas-and-gradle` to `cache-read-only: false` (optional override) so non-`main` branches persist Gradle User Home / local build cache; `setup-gradle` otherwise leaves feature branches read-only.
- Add Action caches for `.gradle/configuration-cache` + `buildSrc/build` on `gradle-ci.yml` check; `buildSrc/build` only on publish.
- Document the write-enabled caching rationale; set `cache-read-only: false` on older templates that call `setup-gradle` directly.

## Test plan
- [ ] Merge, then repin workflows/composite refs to `v0.5.0` and tag `v0.5.0` (same pattern as `v0.4.0` / `v0.4.1`).
- [ ] Bump a consumer (e.g. `kotlin-common`) to `@v0.5.0`, run CI on a feature branch, confirm setup-gradle logs `cache-read-only: false` and saves cache (no “Cache is read-only…”).
- [ ] Second no-op / check-only push on the same branch shows many `FROM-CACHE` hits and a much shorter `./gradlew check`.
- [ ] Confirm publish still works (less wall-time win expected; Packages upload dominates).


Made with [Cursor](https://cursor.com)