### PR TITLE
Allow Gradle cache writes on feature-branch CI

### DIFF
--- a/.github/workflows/gradle-ci.yml
+++ b/.github/workflows/gradle-ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up JDKs and Gradle
-        uses: huanshankeji/.github/actions/setup-javas-and-gradle@v0.4.1
+        uses: huanshankeji/.github/actions/setup-javas-and-gradle@cursor/gradle-cache-read-only-false
         with:
           jdk-versions: ${{ inputs.jdk-versions }}
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}

--- a/.github/workflows/open-source-convention-gradle-maven-publish.yml
+++ b/.github/workflows/open-source-convention-gradle-maven-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up JDKs and Gradle
-        uses: huanshankeji/.github/actions/setup-javas-and-gradle@v0.4.1
+        uses: huanshankeji/.github/actions/setup-javas-and-gradle@cursor/gradle-cache-read-only-false
         with:
           jdk-versions: ${{ inputs.jdk-versions }}
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}

--- a/actions/setup-javas-and-gradle/action.yml
+++ b/actions/setup-javas-and-gradle/action.yml
@@ -25,3 +25,4 @@ runs:
       uses: gradle/actions/setup-gradle@v6
       with:
         cache-encryption-key: ${{ inputs.cache-encryption-key }}
+        cache-read-only: false

--- a/actions/setup-javas-and-gradle/action.yml
+++ b/actions/setup-javas-and-gradle/action.yml
@@ -1,8 +1,8 @@
 name: Setup JDKs and Gradle
 description: >
   Sets up the requested JDKs via setup-javas, then configures Gradle with
-  setup-gradle (Enhanced Caching by default) and a configuration-cache
-  encryption key for cross-job cache reuse.
+  setup-gradle (Enhanced Caching by default) and an optional configuration-cache
+  encryption key passed through to setup-gradle.
 
 inputs:
   jdk-versions:
@@ -10,7 +10,7 @@ inputs:
     required: true
   # https://docs.gradle.org/current/userguide/configuration_cache_requirements.html#config_cache:secrets:configuring_encryption_key
   cache-encryption-key:
-    description: "Base64 AES key for encrypting configuration-cache entries in the Actions cache (pass secrets.GRADLE_ENCRYPTION_KEY; empty skips config-cache caching)"
+    description: "Base64 AES key forwarded to setup-gradle's cache-encryption-key input (empty is allowed)"
     required: true
 
 runs:
@@ -21,6 +21,13 @@ runs:
       with:
         jdk-versions: ${{ inputs.jdk-versions }}
 
+    # setup-gradle@v6 still accepts cache-encryption-key and caches Gradle User Home /
+    # build cache, but it no longer saves/restores project `.gradle/configuration-cache`
+    # across jobs (removed in gradle/actions#884; was not reliable with buildSrc —
+    # gradle/actions#21). Expect "no cached configuration is available" on each fresh
+    # runner even when the previous commit warmed the cache. Even after that returns,
+    # gradle-common Git versioning `*-dev-commit-<sha>` versions fingerprint git HEAD
+    # and would still miss across commits; publish tasks may also disable CC.
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
       with:

--- a/docs/dev-instructions.md
+++ b/docs/dev-instructions.md
@@ -83,10 +83,10 @@ dependencyResolutionManagement {
 - Registry credentials: create GitHub Actions secrets using uppercase snake case (GitHub stores secret names in uppercase). Reusable workflows map them to `ORG_GRADLE_PROJECT_*` environment variables with camelCase Gradle property suffixes (`gprUser` / `gprKey`); do not map secrets in consumer workflow YAML (use `secrets: inherit` on the `uses:` job).
   - GitHub Packages (org secrets): `GPR_USER`, `GPR_KEY`
   - Maven Central + signing (org secrets, release publish): `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`, `SIGNING_IN_MEMORY_KEY_PASSWORD`
-  - Configuration-cache encryption for the Actions cache (org secret): `GRADLE_ENCRYPTION_KEY` (passed into `setup-gradle` / `dependency-submission` as `cache-encryption-key`). If this secret is missing, the workflow still runs but configuration-cache entries are not stored in the Actions cache (`setup-gradle` warns).
+  - Configuration-cache encryption (org secret, recommended name): `GRADLE_ENCRYPTION_KEY` — pass into reusable workflows / `setup-javas-and-gradle` as `cache-encryption-key`. `setup-gradle@v6` no longer saves/restores project `.gradle/configuration-cache` across jobs (see that action); the key is still useful for Gradle’s own CC encryption when that returns.
 - Caching: `gradle/actions` v6 Enhanced Caching is the default (no workflow override). Enable Gradle caches in the consumer’s `gradle.properties` — not via CLI flags in CI:
-  - `org.gradle.caching=true`
-  - `org.gradle.configuration-cache=true`
+  - `org.gradle.caching=true` (build cache is what cross-job reuse relies on today)
+  - `org.gradle.configuration-cache=true` (speeds up within a job / local; not persisted by `setup-gradle@v6`)
 - Publish on all branches (`push: branches: ["**"]`). On `release`: `./gradlew publishAndReleaseToMavenCentral`; otherwise `./gradlew publishAllPublicationsToGitHubPackagesRepository --parallel`.
 - Set `jdk-versions` to the project JVM toolchain; if the toolchain is below 17, also include `17-temurin` for Gradle. Pass `runs-on` explicitly (typically `ubuntu-latest` for JVM OSS publish).
 

--- a/workflow-templates/team-ci.yml
+++ b/workflow-templates/team-ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    uses: huanshankeji/.github/.github/workflows/gradle-ci.yml@v0.4.1
+    uses: huanshankeji/.github/.github/workflows/gradle-ci.yml@cursor/gradle-cache-read-only-false
     secrets: inherit
     with:
       jdk-versions: 11-temurin, 17-temurin

--- a/workflow-templates/team-publish.yml
+++ b/workflow-templates/team-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    uses: huanshankeji/.github/.github/workflows/open-source-convention-gradle-maven-publish.yml@v0.4.1
+    uses: huanshankeji/.github/.github/workflows/open-source-convention-gradle-maven-publish.yml@cursor/gradle-cache-read-only-false
     secrets: inherit
     with:
       jdk-versions: 11-temurin, 17-temurin


### PR DESCRIPTION
## Summary
- Set `cache-read-only: false` in `setup-javas-and-gradle` so `setup-gradle` persists the build cache on non-default branches (default is read-only there).
- Document that `setup-gradle@v6` no longer saves/restores project configuration cache across jobs, and clarify what `GRADLE_ENCRYPTION_KEY` / `cache-encryption-key` still do.
- Temporarily pin reusable workflows and templates to this branch so consumers/CI can exercise the change before a version tag.

## Test plan
- [ ] Confirm CI using `setup-javas-and-gradle` on a feature branch writes Gradle cache entries (not read-only).
- [ ] Confirm successive CI runs on the same branch reuse the build cache as expected.
- [ ] Before merge/tag: re-pin workflows and templates from `@cursor/gradle-cache-read-only-false` back to a release ref.


Made with [Cursor](https://cursor.com)