### PR TITLE
Document avoiding unnecessary changes in agent and review instructions

### DIFF
--- a/docs/code-review-instructions.md
+++ b/docs/code-review-instructions.md
@@ -4,4 +4,6 @@ Instructions to follow during code review.
 
 - Don't suggest removing code commented out in the latest changes or the pull request.
 
-   Code is commented out for a reason. Don't suggest removing code that is newly commented out in the latest changes or the pull request. Only suggest if it's confirmed stale code.
+  Code is commented out for a reason. Don't suggest removing code that is newly commented out in the latest changes or the pull request. Only suggest if it's confirmed stale code.
+
+- Flag possibly unnecessary changes left from debugging or testing (especially in feature PRs), unless they are clearly marked with a TODO to revert / restore. See [Avoid unnecessary changes](general-agent-instructions.md#avoid-unnecessary-changes).

--- a/docs/general-agent-instructions.md
+++ b/docs/general-agent-instructions.md
@@ -138,3 +138,14 @@ When changing code, **preserve existing comments and blank lines** unless the us
 - Do not reformat unrelated parts of a file (whitespace, line breaks, comment style) while making a focused change.
 
 Keep edits minimal: change only what the task requires, and leave surrounding comments and vertical spacing as you found them.
+
+## Avoid unnecessary changes
+
+Try **not** to make unnecessary changes, especially in feature PRs. Focus the diff on the task; do not leave behind drive-by cleanup, speculative refactors, or temporary scaffolding that is not part of the requested work.
+
+If possibly unnecessary changes were made during debugging or testing:
+
+1. **Revert / restore them afterwards** once they are no longer needed.
+2. If such changes are **uncommitted**, revert / restore **before committing**.
+3. If such changes were **committed** and are confirmed unnecessary — especially in a PR — **commit again** to revert / restore.
+4. If they are needed for further review or debugging and **cannot** be reverted / restored immediately, leave a **TODO** in the code **and** in the PR description to revert / restore.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds organization-wide guidance that agents should avoid unnecessary diffs (especially in feature PRs), and should revert / restore temporary debugging or testing changes — before commit when uncommitted, via a follow-up commit when already committed, or with a TODO in code and the PR description when they must stay temporarily.

## Changes

- **`docs/general-agent-instructions.md`**: new [Avoid unnecessary changes](docs/general-agent-instructions.md#avoid-unnecessary-changes) section after the existing minimal-edit guidance.
- **`docs/code-review-instructions.md`**: reviewers should flag leftover unnecessary debugging/testing changes unless marked with a TODO to revert / restore.

## Notes

Docs-only; no CI/build impact in this repository.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77a3daa3-2173-4dbf-af6b-79994fa09b11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77a3daa3-2173-4dbf-af6b-79994fa09b11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

