### PR TITLE
Say “PRs” instead of “feature PRs” in avoid-unnecessary-changes guidance

### DIFF
--- a/docs/code-review-instructions.md
+++ b/docs/code-review-instructions.md
@@ -6,4 +6,4 @@ Instructions to follow during code review.
 
   Code is commented out for a reason. Don't suggest removing code that is newly commented out in the latest changes or the pull request. Only suggest if it's confirmed stale code.
 
-- Flag possibly unnecessary changes left from debugging or testing (especially in feature PRs), unless they are clearly marked with a TODO to revert / restore. See [Avoid unnecessary changes](general-agent-instructions.md#avoid-unnecessary-changes).
+- Flag possibly unnecessary changes left from debugging or testing (especially in PRs), unless they are clearly marked with a TODO to revert / restore. See [Avoid unnecessary changes](general-agent-instructions.md#avoid-unnecessary-changes).

--- a/docs/general-agent-instructions.md
+++ b/docs/general-agent-instructions.md
@@ -141,7 +141,7 @@ Keep edits minimal: change only what the task requires, and leave surrounding co
 
 ## Avoid unnecessary changes
 
-Try **not** to make unnecessary changes, especially in feature PRs. Focus the diff on the task; do not leave behind drive-by cleanup, speculative refactors, or temporary scaffolding that is not part of the requested work.
+Try **not** to make unnecessary changes, especially in PRs. Focus the diff on the task; do not leave behind drive-by cleanup, speculative refactors, or temporary scaffolding that is not part of the requested work.
 
 If possibly unnecessary changes were made during debugging or testing:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #36: broaden the wording from “feature PRs” to “PRs” in both the agent and code-review instructions.

## Changes

- `docs/general-agent-instructions.md`
- `docs/code-review-instructions.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77a3daa3-2173-4dbf-af6b-79994fa09b11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77a3daa3-2173-4dbf-af6b-79994fa09b11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

