### PR TITLE
Simplify general agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This repo is **huanshankeji/.github**: organization profile, shared docs, composite GitHub Actions, and workflow templates. It is **not** a Gradle/Kotlin application. There is no `./gradlew`, dev server, or database to run here.
 
-For organization-wide Kotlin library standards, the public repo catalog, shared workflows, and [agent skills](docs/general-agent-instructions.md#agent-skills), see [docs/general-agent-instructions.md](docs/general-agent-instructions.md).
+For organization-wide Kotlin library standards, the repo catalog, and shared workflows, see [docs/general-agent-instructions.md](docs/general-agent-instructions.md).
 
 The `copilot/` directory is **no longer maintained**. Do not edit files there; use this `AGENTS.md` and `docs/` instead.
 

--- a/docs/general-agent-instructions.md
+++ b/docs/general-agent-instructions.md
@@ -24,9 +24,9 @@ This file is [`docs/general-agent-instructions.md`](https://github.com/huanshank
 
 ---
 
-## Kotlin project hierarchy
+## Open source Kotlin project hierarchy
 
-**Only non-fork Kotlin repositories** created by `@huanshankeji` are listed below.
+**Only public, non-fork Kotlin repositories** created by `@huanshankeji` are listed below.
 
 ### Dependency layers
 

--- a/docs/general-agent-instructions.md
+++ b/docs/general-agent-instructions.md
@@ -1,6 +1,6 @@
-# Agent instructions — Huanshankeji open source
+# Agent instructions — Huanshankeji
 
-Instructions for AI coding agents working on **public Kotlin libraries** published by [Chengdu Huanshan Technology](https://github.com/huanshankeji) (`@huanshankeji`). We focus on [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html), [Vert.x](https://vertx.io/), functional programming, and type-safety.
+Instructions for AI coding agents working on **Kotlin libraries** published by [Chengdu Huanshan Technology](https://github.com/huanshankeji) (`@huanshankeji`). We focus on [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html), [Vert.x](https://vertx.io/), functional programming, and type-safety.
 
 This file is [`docs/general-agent-instructions.md`](https://github.com/huanshankeji/.github/blob/main/docs/general-agent-instructions.md) in the [`.github`](https://github.com/huanshankeji/.github) organization repository. For **this** repo, start with the root [`AGENTS.md`](../AGENTS.md). Other projects may add their own `AGENTS.md`, `CLAUDE.md`, or `.github/copilot-instructions.md`; **follow those for repo-specific build steps and architecture**, and use this file for organization-wide standards and library relationships.
 
@@ -8,7 +8,7 @@ This file is [`docs/general-agent-instructions.md`](https://github.com/huanshank
 
 ## Required reading
 
-### Every Kotlin open-source task
+### Every Kotlin task
 
 | Topic | Document |
 | --- | --- |
@@ -24,50 +24,13 @@ This file is [`docs/general-agent-instructions.md`](https://github.com/huanshank
 
 ---
 
-## Agent skills
+## Kotlin project hierarchy
 
-We publish reusable [Agent Skills](https://agentskills.io) for workflows that agents should not improvise. **When a task matches a skill’s description, load and follow that skill** (via your platform’s skill tool, or by reading the skill’s `SKILL.md`) instead of inventing steps from scratch.
-
-| Repository | Scope |
-| --- | --- |
-| [kotlin-skills](https://github.com/huanshankeji/kotlin-skills) | Kotlin, Gradle, and JVM/KMP build workflows |
-| [skills](https://github.com/huanshankeji/skills) | General agent skills (not Kotlin-specific) |
-
-Also see [Kotlin/kotlin-agent-skills](https://github.com/Kotlin/kotlin-agent-skills) for skills maintained by JetBrains.
-
-### Installation
-
-Install into the target repository (or your global skills directory) with the [skills CLI](https://github.com/vercel-labs/skills):
-
-```bash
-npx skills add huanshankeji/kotlin-skills
-npx skills add huanshankeji/skills
-```
-
-Or copy individual skill folders from a repo’s `skills/` directory into a project-local skills path (for example `.agents/skills/`, `.github/skills/`, or `.claude/skills/`). See each repository’s README for layout details.
-
-Do **not** commit installed skill files to the repository unless explicitly asked to install skills there.
-
-### kotlin-skills catalog
-
-| Skill | Use when |
-| --- | --- |
-| [gradle-wrapper-update](https://github.com/huanshankeji/kotlin-skills/tree/main/skills/gradle-wrapper-update) | Upgrading or downgrading the Gradle wrapper (`gradlew`, `gradle-wrapper.properties`, `gradle-wrapper.jar`) |
-| [kotlin-debugging-unresolved-reference-file-clash](https://github.com/huanshankeji/kotlin-skills/tree/main/skills/kotlin-debugging-unresolved-reference-file-clash) | Kotlin JVM or KMP reports “Unresolved reference” (or similar) even though the symbol exists and dependencies look correct — especially after adding, moving, or renaming `.kt` files with top-level declarations |
-
-### skills catalog
-
-Check [skills](https://github.com/huanshankeji/skills) for general-purpose skills that apply across stacks. Prefer a repo-local or org skill over ad hoc steps when one matches the task.
-
----
-
-## Open source Kotlin project hierarchy
-
-**Only public, non-fork Kotlin repositories** created by `@huanshankeji` are listed below.
+**Only non-fork Kotlin repositories** created by `@huanshankeji` are listed below.
 
 ### Dependency layers
 
-Build tooling sits at the bottom; runtime libraries stack upward. Arrows mean “depends on (directly or via published artifacts / build logic)”.
+Build tooling sits at the bottom; libraries stack upward. Arrows mean “depends on (directly or via published artifacts / build logic)”.
 
 ```mermaid
 flowchart TB
@@ -91,7 +54,7 @@ flowchart TB
   compose_html --> cmp_unified
 ```
 
-- **gradle-common** — Shared Gradle plugins (`kotlin-common-gradle-plugins`, `gradle-plugins`, `common-gradle-dependencies`, etc.). Other repos pull these into `buildSrc` for aligned Kotlin, Compose, Dokka, and dependency versions. Not a runtime app dependency for end users, but required to build sibling libraries.
+- **gradle-common** — Shared Gradle plugins (`kotlin-common-gradle-plugins`, `gradle-plugins`, `common-gradle-dependencies`, etc.). Other repos pull these into `buildSrc` for aligned Kotlin, Compose, Dokka, and dependency versions. Not a library dependency (`api` / `implementation`) for consumers, but required to build sibling libraries.
 - **kotlin-common** — Foundation Kotlin/KMP extensions (core, coroutines, Exposed, Vert.x, Ktor, Arrow, etc.). Some other libraries depend on one or more `kotlin-common-*` modules.
 - **exposed-gadt-mapping** — Exposed DSL mappings with GADT-style modeling. **No longer actively maintained**; mapping code is usually generated ad hoc with AI agents instead. Still published and used by the optional `crud-with-mapper` module in **exposed-vertx-sql-client**.
 - **exposed-vertx-sql-client** — Run Exposed statements on Vert.x reactive SQL clients (PostgreSQL, MySQL, Oracle, SQL Server). The optional **`crud-with-mapper`** module integrates **exposed-gadt-mapping**.
@@ -112,7 +75,6 @@ flowchart TB
 ### Related organization resources
 
 - **Profile / intro:** [profile/README.md](../profile/README.md)
-- **Agent skills:** [kotlin-skills](https://github.com/huanshankeji/kotlin-skills), [skills](https://github.com/huanshankeji/skills) — see [Agent skills](#agent-skills)
 - **Shared CI & Actions:** workflow templates and composite actions in this repo (`workflow-templates/`, `actions/`)
 
 ---
@@ -121,9 +83,8 @@ flowchart TB
 
 1. Open the target repo and read its `README.md`, `CONTRIBUTING.md`, and any repo-local agent file (`AGENTS.md`, `.github/copilot-instructions.md`).
 2. Apply the [required reading](#required-reading) for the task type.
-3. If the task matches an [agent skill](#agent-skills) (Gradle wrapper updates, misleading Kotlin “Unresolved reference” errors, or a skill in [skills](https://github.com/huanshankeji/skills)), install or load that skill and follow it.
-4. If the task spans multiple repos (typical with `*-dev-commit-*` / dirty-SNAPSHOT dependencies), follow [dev-instructions.md](dev-instructions.md) before running `./gradlew check` or `./gradlew build`.
-5. When working across **multiple Gradle projects** in one session, pass **`--no-daemon`** on every `./gradlew` invocation (and run `./gradlew --stop` first if daemons are already running). Many concurrent daemons can exhaust memory and crash the machine.
+3. If the task spans multiple repos (typical with `*-dev-commit-*` / dirty-SNAPSHOT dependencies), follow [dev-instructions.md](dev-instructions.md) before running `./gradlew check` or `./gradlew build`.
+4. When working across **multiple Gradle projects** in one session, pass **`--no-daemon`** on every `./gradlew` invocation (and run `./gradlew --stop` first if daemons are already running). Many concurrent daemons can exhaust memory and crash the machine.
 
 When instructions conflict, **repo-local agent docs and maintainers’ task directions win**; this file provides the shared baseline and library map.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tighten `docs/general-agent-instructions.md` for broader applicability and less duplication:

- Remove “open source” / “public” framing from the global intro and required-reading headings so the baseline reads as org-wide Kotlin library guidance.
- Keep “open source” / “public” in the **Open source Kotlin project hierarchy** section, where the catalog is limited to public open-source repos.
- Remove the duplicate **Agent skills** section (and related links/steps); skills live in their own repos.
- Replace “runtime (app) dependency” wording with Gradle-oriented **library dependency** (`api` / `implementation`) language, contrasting build logic / `buildSrc` usage.

Also updates the `AGENTS.md` pointer so it no longer links to the removed skills anchor.

## Notes on terminology

Gradle does have `runtimeOnly` / `runtimeClasspath`, but “runtime (app) dependencies” as used here was closer to the npm-style “deps needed when the app runs” contrast with build tooling. The clearer Gradle contrast for `gradle-common` is: build logic / plugins vs library dependencies declared with `api` / `implementation`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1678500b-caad-4e2a-b42a-0d210ed61ed1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1678500b-caad-4e2a-b42a-0d210ed61ed1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

