### PR TITLE
Drop public/open-source framing from Cursor plugin scope

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "chengduhuanshankeji@hotmail.com"
   },
   "metadata": {
-    "description": "Cursor plugins for the @huanshankeji open-source organization",
+    "description": "Cursor plugins for the @huanshankeji organization",
     "version": "0.1.0"
   },
   "plugins": [

--- a/plugins/huanshankeji-agent-instructions/rules/org-agent-instructions.mdc
+++ b/plugins/huanshankeji-agent-instructions/rules/org-agent-instructions.mdc
@@ -7,7 +7,7 @@ alwaysApply: true
 
 This rule is **always applied**. It is not optional guidance.
 
-When working on **public Kotlin libraries** (or related open-source work) published by `@huanshankeji` / [Chengdu Huanshan Technology](https://github.com/huanshankeji), you **MUST** load and follow the organization agent baseline **before** exploring, planning, or editing — do **not** skip this fetch because a repo `AGENTS.md` only links to it.
+When working on **Kotlin libraries** published by `@huanshankeji` / [Chengdu Huanshan Technology](https://github.com/huanshankeji), you **MUST** load and follow the organization agent baseline **before** exploring, planning, or editing — do **not** skip this fetch because a repo `AGENTS.md` only links to it.
 
 ## Canonical source (load the full document)
 
@@ -20,7 +20,7 @@ Use your available tools (`Read`, `WebFetch`, `gh api`, `curl`, etc.). Treat a f
 
 ## After loading
 
-1. Follow that document’s **Required reading**, **Agent skills**, repo hierarchy, and working practices for the task type.
+1. Follow that document’s **Required reading**, repo hierarchy, and working practices for the task type.
 2. Load linked required docs (Kotlin style, dev/snapshot instructions, engineering guidelines; code-review instructions when reviewing) the same way — do not invent org standards from memory.
 
 ## Precedence


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Align the Cursor plugin with [#38](https://github.com/huanshankeji/.github/pull/38): the always-apply rule applies to **Kotlin libraries** generally (including internal), not only “public” / “open-source” work.

## Changes

- `rules/org-agent-instructions.mdc`: “public Kotlin libraries (or related open-source work)” → “Kotlin libraries”; drop stale **Agent skills** mention (removed in #38)
- `.cursor-plugin/marketplace.json`: “open-source organization” → “organization”

The open-source project hierarchy catalog in `docs/general-agent-instructions.md` is unchanged (still correctly scoped to public repos).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-594b7983-9699-4103-aa65-24dbc147be52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-594b7983-9699-4103-aa65-24dbc147be52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

